### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/jgosmann/gen-semver-tags/compare/v0.1.0...v0.1.1) - 2025-02-27
+
+### Other
+
+- Add some more information to the readme
+- Relax version constraint for gen-semver-tags in pipeline
+- Build Docker image for correct version
+- Fix Docker image tag generation
+- Use PAT for release-plz
+
 ## 0.1.0 - 2025-02-27
 
 Initial release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "gen-semver-tags"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gen-semver-tags"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Jan Gosmann"]
 description = "Generate a set of SemVer tags, e.g. to tag container images."


### PR DESCRIPTION



## 🤖 New release

* `gen-semver-tags`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/jgosmann/gen-semver-tags/compare/v0.1.0...v0.1.1) - 2025-02-27

### Other

- Add some more information to the readme
- Relax version constraint for gen-semver-tags in pipeline
- Build Docker image for correct version
- Fix Docker image tag generation
- Use PAT for release-plz
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).